### PR TITLE
Improve train stopping on big maps with much lines and vehicles

### DIFF
--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -239,7 +239,7 @@ function fillLineTable()
         local lineColour = api.gui.comp.TextView.new("●")
         lineColour:setName("timetable-linecolour-" .. timetableHelper.getLineColour(v.id))
         lineColour:setStyleClassList({"timetable-linecolour"})
-        lineName = api.gui.comp.TextView.new(v.name)
+        local lineName = api.gui.comp.TextView.new(v.name)
         lineNames[k] = v.name
         lineName:setName("timetable-linename")
         local buttonImage = api.gui.comp.ImageView.new("ui/checkbox0.tga")
@@ -248,11 +248,13 @@ function fillLineTable()
         button:setStyleClassList({"timetable-avtivateTimetableButton"})
         button:setGravity(1,0.5)
         button:onClick(function()
-            imageVeiw = buttonImage
-            hasTimetable = timetable.hasTimetable(v.id)
+            local imageVeiw = buttonImage
+            local hasTimetable = timetable.hasTimetable(v.id)
             if  hasTimetable then
                 timetable.setHasTimetable(v.id,false)
                 imageVeiw:setImage("ui/checkbox0.tga", false)
+                -- start all stopped vehicles again if the timetable is disabled for this line
+                timetable.startAllLineVehicles(v.id)
             else
                 timetable.setHasTimetable(v.id,true)
                 imageVeiw:setImage("ui/checkbox1.tga", false)

--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -733,16 +733,16 @@ end
 --------------------- OTHER ---------------------------------
 -------------------------------------------------------------
 
-function timetableCoroutine() 
+local function timetableCoroutine()
     while true do
-        local lines = timetableHelper.getAllRailLines()
-        for vehicle,line in pairs(timetableHelper.getAllRailVehicles()) do
+        local vehiclesWithLines = timetableHelper.getAllTimetableRailVehicles(timetable.hasTimetable)
+        for vehicle,line in pairs(vehiclesWithLines) do
             if timetableHelper.isInStation(vehicle) then
-                if timetable.hasTimetable(line) and timetable.waitingRequired(vehicle) then
+                if timetable.waitingRequired(vehicle) then
                     timetableHelper.stopVehicle(vehicle)
                 else
                     timetableHelper.startVehicle(vehicle)
-                end      
+                end
             end
             coroutine.yield()
         end

--- a/res/scripts/celmi/timetables/timetable.lua
+++ b/res/scripts/celmi/timetables/timetable.lua
@@ -205,7 +205,7 @@ function timetable.waitingRequired(vehicle)
     if not timetableObject[currentLineString].stations[currentStop].conditions then return false end
     if not timetableObject[currentLineString].stations[currentStop].conditions.type then return false end
 
-    if timetableHelper.getTimeUntilDeparture(vehicle) >= 2 then return false end
+    if timetableHelper.getTimeUntilDeparture(vehicle) >= 10 then return false end
 
     if not currentlyWaiting[currentLineString] then currentlyWaiting[currentLineString] = {stations = {}} end
     if not currentlyWaiting[currentLineString].stations[currentStop] then currentlyWaiting[currentLineString].stations[currentStop] = { currentlyWaiting = {}} end

--- a/res/scripts/celmi/timetables/timetable.lua
+++ b/res/scripts/celmi/timetables/timetable.lua
@@ -205,7 +205,7 @@ function timetable.waitingRequired(vehicle)
     if not timetableObject[currentLineString].stations[currentStop].conditions then return false end
     if not timetableObject[currentLineString].stations[currentStop].conditions.type then return false end
 
-    if timetableHelper.getTimeUntilDeparture(vehicle) >= 10 then return false end
+    if timetableHelper.getTimeUntilDeparture(vehicle) >= 2 then return false end
 
     if not currentlyWaiting[currentLineString] then currentlyWaiting[currentLineString] = {stations = {}} end
     if not currentlyWaiting[currentLineString].stations[currentStop] then currentlyWaiting[currentLineString].stations[currentStop] = { currentlyWaiting = {}} end

--- a/res/scripts/celmi/timetables/timetable.lua
+++ b/res/scripts/celmi/timetables/timetable.lua
@@ -285,6 +285,20 @@ function timetable.setHasTimetable(line, bool)
     return bool
 end
 
+--- Start all vehicles of given line.
+---@param line table line id
+function timetable.startAllLineVehicles(line)
+    for _, vehicle in pairs(timetableHelper.getVehiclesOnLine(line)) do
+        if timetableHelper.isInStation(vehicle) then
+            local currentLine = tostring(timetableHelper.getCurrentLine(vehicle))
+            local currentStop = timetableHelper.getCurrentStation(vehicle)
+            if currentlyWaiting[currentLine] and currentlyWaiting[currentLine].stations[currentStop] then
+                currentlyWaiting[currentLine].stations[currentStop].currentlyWaiting = {}
+            end
+            timetableHelper.startVehicle(vehicle)
+        end
+    end
+end
 
 
 -------------- UTILS FUNCTIONS ----------

--- a/res/scripts/celmi/timetables/timetable.lua
+++ b/res/scripts/celmi/timetables/timetable.lua
@@ -199,77 +199,78 @@ function timetable.waitingRequired(vehicle)
     local time = timetableHelper.getTime()
     local currentLine = timetableHelper.getCurrentLine(vehicle)
     local currentStop = timetableHelper.getCurrentStation(vehicle)
-    if not timetableObject[tostring(currentLine)] then return false end
-    if not timetableObject[tostring(currentLine)].stations[currentStop] then return false end
-    if not timetableObject[tostring(currentLine)].stations[currentStop].conditions then return false end
-    if not timetableObject[tostring(currentLine)].stations[currentStop].conditions.type then return false end
+    local currentLineString = tostring(currentLine)
+    if not timetableObject[currentLineString] then return false end
+    if not timetableObject[currentLineString].stations[currentStop] then return false end
+    if not timetableObject[currentLineString].stations[currentStop].conditions then return false end
+    if not timetableObject[currentLineString].stations[currentStop].conditions.type then return false end
 
     if timetableHelper.getTimeUntilDeparture(vehicle) >= 2 then return false end
 
-    if not currentlyWaiting[tostring(currentLine)] then currentlyWaiting[tostring(currentLine)] = {stations = {}} end
-    if not currentlyWaiting[tostring(currentLine)].stations[currentStop] then currentlyWaiting[tostring(currentLine)].stations[currentStop] = { currentlyWaiting = {}} end
-    if timetableObject[tostring(currentLine)].stations[currentStop].conditions.type == "ArrDep" then 
+    if not currentlyWaiting[currentLineString] then currentlyWaiting[currentLineString] = {stations = {}} end
+    if not currentlyWaiting[currentLineString].stations[currentStop] then currentlyWaiting[currentLineString].stations[currentStop] = { currentlyWaiting = {}} end
+    if timetableObject[currentLineString].stations[currentStop].conditions.type == "ArrDep" then 
         -- am I currently waiting or just arrived?
         
-        if not (currentlyWaiting[tostring(currentLine)].stations[currentStop].currentlyWaiting[vehicle]) then
+        if not (currentlyWaiting[currentLineString].stations[currentStop].currentlyWaiting[vehicle]) then
             -- check if is about to depart
 
-            if currentlyWaiting[tostring(currentLine)].stations[currentStop].outboundTime and (currentlyWaiting[tostring(currentLine)].stations[currentStop].outboundTime + 40) > time then
+            if currentlyWaiting[currentLineString].stations[currentStop].outboundTime and (currentlyWaiting[currentLineString].stations[currentStop].outboundTime + 40) > time then
                 return false
             end
 
             -- just arrived
-            local nextConstraint = timetable.getNextConstraint(timetableObject[tostring(currentLine)].stations[currentStop].conditions.ArrDep, time)
+            local nextConstraint = timetable.getNextConstraint(timetableObject[currentLineString].stations[currentStop].conditions.ArrDep, time)
             if not nextConstraint then 
                 -- no constraints set
-                currentlyWaiting[tostring(currentLine)].stations[currentStop].currentlyWaiting = {}
+                currentlyWaiting[currentLineString].stations[currentStop].currentlyWaiting = {}
                 return false 
             end
             if timetable.beforeDepature(nextConstraint, time) then
                 -- Constraint set and I need to wait
-                currentlyWaiting[tostring(currentLine)].stations[currentStop].currentlyWaiting[vehicle] = {type = "ArrDep", arrivalTime = time,  constraint = nextConstraint}
+                currentlyWaiting[currentLineString].stations[currentStop].currentlyWaiting[vehicle] = {type = "ArrDep", arrivalTime = time,  constraint = nextConstraint}
                 return true
             else
                 -- Constraint set and its time to depart
-                currentlyWaiting[tostring(currentLine)].stations[currentStop].outboundTime = time
-                currentlyWaiting[tostring(currentLine)].stations[currentStop].currentlyWaiting = {}
+                currentlyWaiting[currentLineString].stations[currentStop].outboundTime = time
+                currentlyWaiting[currentLineString].stations[currentStop].currentlyWaiting = {}
                 return false
             end
         else
             -- already waiting
-            local arivvalTime = currentlyWaiting[tostring(currentLine)].stations[currentStop].currentlyWaiting[vehicle].arrivalTime
-            local constraint = timetable.getNextConstraint(timetableObject[tostring(currentLine)].stations[currentStop].conditions.ArrDep, arivvalTime)
+            local arivvalTime = currentlyWaiting[currentLineString].stations[currentStop].currentlyWaiting[vehicle].arrivalTime
+            local constraint = timetable.getNextConstraint(timetableObject[currentLineString].stations[currentStop].conditions.ArrDep, arivvalTime)
             if timetable.beforeDepature(constraint, time) then
                 -- need to continue waiting
                 return true
             else
                 -- done waiting
-                currentlyWaiting[tostring(currentLine)].stations[currentStop].outboundTime = time
-                currentlyWaiting[tostring(currentLine)].stations[currentStop].currentlyWaiting = {}
+                currentlyWaiting[currentLineString].stations[currentStop].outboundTime = time
+                currentlyWaiting[currentLineString].stations[currentStop].currentlyWaiting = {}
                 return false
             end
         end
         -- edge cases, should not happen
-        currentlyWaiting[tostring(currentLine)].stations[currentStop].outboundTime = time
-        currentlyWaiting[tostring(currentLine)].stations[currentStop].currentlyWaiting = {}
+        currentlyWaiting[currentLineString].stations[currentStop].outboundTime = time
+        currentlyWaiting[currentLineString].stations[currentStop].currentlyWaiting = {}
         return false
 
     --------------------------------------------------------------------------------------------------------------------------------------
     --------------------------------------- DEBOUNCE ------------------------------------------------------------------------------------
     
-    elseif timetableObject[tostring(currentLine)].stations[currentStop].conditions.type == "debounce" then
+    elseif timetableObject[currentLineString].stations[currentStop].conditions.type == "debounce" then
         local previousDepartureTime = timetableHelper.getPreviousDepartureTime(tonumber(vehicle)) 
         condition = timetable.getConditions(currentLine, currentStop, "debounce")
         if not condition[1] then condition[1] = 0 end
         if not condition[2] then condition[2] = 0 end
         if time > previousDepartureTime + ((condition[1] * 60)  + condition[2]) then
-            currentlyWaiting[tostring(currentLine)].stations[currentStop].currentlyWaiting = {}
+            currentlyWaiting[currentLineString].stations[currentStop].currentlyWaiting = {}
             return false
         else
             return true
         end
     else 
-        currentlyWaiting[tostring(currentLine)].stations[currentStop].currentlyWaiting = {}
+        currentlyWaiting[currentLineString].stations[currentStop].currentlyWaiting = {}
         return false
     end
 end

--- a/res/scripts/celmi/timetables/timetable_helper.lua
+++ b/res/scripts/celmi/timetables/timetable_helper.lua
@@ -226,6 +226,21 @@ function timetableHelper.getAllRailVehicles()
     return res
 end
 
+---@param hasTimetable function lineId -> boolean
+-- returns [{vehicleID: lineID}]
+function timetableHelper.getAllTimetableRailVehicles(hasTimetable)
+    local res = {}
+    local vehicleMap = api.engine.system.transportVehicleSystem.getLine2VehicleMap()
+    for k,v in pairs(vehicleMap) do
+        if (hasTimetable(k)) then
+            for k2,v2 in pairs(v) do
+                res[tostring(v2)] = k 
+            end
+        end
+    end
+    return res
+end
+
 function timetableHelper.isInStation(vehicle)
     if not(type(vehicle) == "string") then print("wrong type") return false end
     local v = api.engine.getComponent(tonumber(vehicle), 70)
@@ -300,7 +315,7 @@ function timetableHelper.maximumArray(arr)
 end
 
 function timetableHelper.getTimeUntilDeparture(vehicle)
-    return api.engine.getComponent(tonumber(vehicle), 70).timeUntilCloseDoors
+    return api.engine.getComponent(tonumber(vehicle), api.type.ComponentType.TRANSPORT_VEHICLE).timeUntilCloseDoors
 end
 
 return timetableHelper

--- a/res/scripts/celmi/timetables/timetable_helper.lua
+++ b/res/scripts/celmi/timetables/timetable_helper.lua
@@ -242,7 +242,6 @@ function timetableHelper.getAllTimetableRailVehicles(hasTimetable)
 end
 
 function timetableHelper.isInStation(vehicle)
-    if not(type(vehicle) == "string") then print("wrong type") return false end
     local v = api.engine.getComponent(tonumber(vehicle), 70)
     return v and v.state == 2
 end


### PR DESCRIPTION
Really love your script, but it seems that on my big map it is unable to stop the train within the two seconds before the departure time. 

So I played around a bit.

I tried to improve the performance of the coroutine function, but it was still not always stopping the train. 
So I increased the time before departure to 10 (eventually 5 is also enough for my current save), I think it will be a good idea to make this configurable. What do you think?

This fixed #7 for me

I'm looking forward to your feedback