### PR TITLE
Performance Improvements on large maps

### DIFF
--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -735,10 +735,9 @@ end
 
 function timetableCoroutine() 
     while true do
-        local lines = timetableHelper.getAllRailLines()
-        for vehicle,line in pairs(timetableHelper.getAllRailVehicles()) do
+        for vehicle,line in pairs(timetableHelper.getAllTimetableRailVehicles()) do
             if timetableHelper.isInStation(vehicle) then
-                if timetable.hasTimetable(line) and timetable.waitingRequired(vehicle) then
+                if timetable.waitingRequired(vehicle) then
                     timetableHelper.stopVehicle(vehicle)
                 else
                     timetableHelper.startVehicle(vehicle)

--- a/res/scripts/celmi/timetables/timetable_helper.lua
+++ b/res/scripts/celmi/timetables/timetable_helper.lua
@@ -226,6 +226,20 @@ function timetableHelper.getAllRailVehicles()
     return res
 end
 
+-- returns [{vehicleID: lineID}]
+function timetableHelper.getAllTimetableRailVehicles()
+    local res = {}
+    local vehicleMap = api.engine.system.transportVehicleSystem.getLine2VehicleMap()
+    for k,v in pairs(vehicleMap) do
+        if timetable.hasTimetable(k)
+            for k2,v2 in pairs(v) do
+                res[tostring(v2)] = k 
+            end
+        end
+    end
+    return res
+end
+
 function timetableHelper.isInStation(vehicle)
     if not(type(vehicle) == "string") then print("wrong type") return false end
     local v = api.engine.getComponent(tonumber(vehicle), 70)

--- a/res/scripts/celmi/timetables/timetable_helper.lua
+++ b/res/scripts/celmi/timetables/timetable_helper.lua
@@ -231,7 +231,7 @@ function timetableHelper.getAllTimetableRailVehicles()
     local res = {}
     local vehicleMap = api.engine.system.transportVehicleSystem.getLine2VehicleMap()
     for k,v in pairs(vehicleMap) do
-        if timetable.hasTimetable(k)
+        if timetable.hasTimetable(k) then
             for k2,v2 in pairs(v) do
                 res[tostring(v2)] = k 
             end


### PR DESCRIPTION
So here are some performance improvements (correct me if I forget about something).

Problem:
Issues on large maps with many vehicles. See #16 and #7 

Solution:
Line 738: unnecessary?
Don't check isInStation, hasTimetable and waitingRequired for each vehicle. Instead only get the vehicles with an active timetable. This is made by adding the new function timetableHelper.getAllTimetableRailVehicles(). It's basically the same as getAllRailVehicles but before itarating over the vehicles it checks if this line has a timetable. 