### PR TITLE
Implemented automatic generation of recurring departures, resolves #75, probably resolves #63

### DIFF
--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -617,7 +617,7 @@ function timetableGUI.makeArrDepWindow(lineID, stationID)
     local conditions = timetable.getConditions(lineID,stationID, "ArrDep")
 
     -- setup separation selector
-    local separationList = {1, 1.5, 2, 2.5, 3, 4, 5, 6, 7.5, 10, 12, 15, 20, 30}
+    local separationList = {30, 20, 15, 12, 10, 7.5, 6, 5, 4, 3, 2.5, 2, 1.5, 1}
     local separationCombo = api.gui.comp.ComboBox.new()
     for k,v in ipairs(separationList) do 
         separationCombo:addItem(v .. " min (" .. 60 / v .. "/h)")

--- a/res/config/game_script/timetable_gui.lua
+++ b/res/config/game_script/timetable_gui.lua
@@ -617,7 +617,7 @@ function timetableGUI.makeArrDepWindow(lineID, stationID)
     local conditions = timetable.getConditions(lineID,stationID, "ArrDep")
 
     -- setup separation selector
-    local separationList = {1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30}
+    local separationList = {1, 1.5, 2, 2.5, 3, 4, 5, 6, 7.5, 10, 12, 15, 20, 30}
     local separationCombo = api.gui.comp.ComboBox.new()
     for k,v in ipairs(separationList) do 
         separationCombo:addItem(v .. " min (" .. 60 / v .. "/h)")
@@ -639,14 +639,9 @@ function timetableGUI.makeArrDepWindow(lineID, stationID)
         end
 
         -- generate recurring conditions
-        local separation = separationList[separationCombo:getCurrentIndex()+1]
-        for i = 1, 60/separation-1 do
-            timetable.addCondition(lineID,stationID, {type = "ArrDep", ArrDep = {{
-                (templateArrDep[1] + i*separation) % 60,    -- arrival minute
-                templateArrDep[2],                          -- arrival second
-                (templateArrDep[3] + i*separation) % 60,    -- departure minute
-                templateArrDep[4]                           -- departure second
-            }}})
+        local separation = separationList[separationCombo:getCurrentIndex() + 1]
+        for i = 1, 60 / separation - 1 do
+            timetable.addCondition(lineID,stationID, {type = "ArrDep", ArrDep = {timetable.shiftConstraint(templateArrDep, i * separation * 60)}})
         end
 
         -- cleanup

--- a/res/scripts/celmi/timetables/timetable.lua
+++ b/res/scripts/celmi/timetables/timetable.lua
@@ -386,6 +386,26 @@ function timetable.getTimeDifference(a, b)
     end
 end
 
+---Shifts a time in minutes and seconds by some offset
+---Helper function for shiftConstraint() 
+---@param time table in format like: {28,45}
+---@param offset number in seconds 
+---@return table shifted time, example: {30,0}
+function timetable.shiftTime(time, offset)
+    local timeSeconds = (time[1] * 60 + time[2] + offset) % 3600
+    return {math.floor(timeSeconds / 60), timeSeconds % 60}
+end
+
+
+---Shifts a constraint by some offset
+---@param constraint table in format like: {30,0,59,0}
+---@param offset number in seconds 
+---@return constraint table shifted time, example: {31,0,0,0}
+function timetable.shiftConstraint(constraint, offset)
+    local shiftArr = timetable.shiftTime({constraint[1], constraint[2]}, offset)
+    local shiftDep = timetable.shiftTime({constraint[3], constraint[4]}, offset)
+    return {shiftArr[1], shiftArr[2], shiftDep[1], shiftDep[2]}
+end
 
 return timetable
 


### PR DESCRIPTION
These changes make it easier to create timetables when trains depart at regular intervals.

You can choose the separation between trains and generate the timetable for the entire hour. It takes the first timetable entry as a template, deletes the following entries and then generates entries that are offset from the template by a multiple of the separation value.

It looks like this:
![grafik](https://user-images.githubusercontent.com/10237613/120724161-85640400-c4d3-11eb-82a3-8bd83b4ef885.png)

There are three issues I'm aware of right now and need feedback on:
- The strings "Separation" and "Generate" need to be internationalized
- All timetable entries apart from the template are removed without warning
- I haven't put much thought into UI/UX design